### PR TITLE
Reduce package size & fix git's url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "reduken",
   "version": "1.0.12",
-  "description":
-    "Redis style structures as redux reducers, actions and selectors",
+  "description": "Redis style structures as redux reducers, actions and selectors",
   "main": "main.js",
   "repository": {
     "type": "git",
@@ -16,25 +15,30 @@
     "analyze": "webpack --json | webpack-bundle-size-analyzer",
     "prepublishOnly": "jest && webpack"
   },
-  "keywords": ["reducer", "redux", "redis", "hash"],
+  "keywords": [
+    "reducer",
+    "redux",
+    "redis",
+    "hash"
+  ],
   "author": "redradix",
   "license": "ISC",
   "dependencies": {
     "dot-prop-immutable": "^1.4.0",
     "invariant": "^2.2.2",
     "lodash.curry": "^4.1.1",
-    "lodash.map": "^4.6.0",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.39",
     "@babel/preset-env": "^7.0.0-beta.39",
-    "babel-loader": "8.0.0-beta.0",
-    "babel-preset-env": "^1.6.1",
-    "webpack": "^3.10.0",
     "babel-cli": "^6.26.0",
     "babel-jest": "^22.1.0",
-    "jest": "^22.1.4"
+    "babel-loader": "8.0.0-beta.0",
+    "babel-preset-env": "^1.6.1",
+    "jest": "^22.1.4",
+    "webpack": "^3.10.0",
+    "webpack-bundle-size-analyzer": "^2.7.0"
   },
   "bugs": {
     "url": "https://github.com/redradix/reduken/issues"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "reduken",
   "version": "1.0.12",
-  "description": "Redis style structures as redux reducers, actions and selectors",
+  "description":
+    "Redis style structures as redux reducers, actions and selectors",
   "main": "main.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redradix/rdx.git"
+    "url": "git+https://github.com/redradix/reduken.git"
   },
   "scripts": {
     "test": "jest",
@@ -14,12 +15,7 @@
     "build": "jest && webpack",
     "prepublishOnly": "jest && webpack"
   },
-  "keywords": [
-    "reducer",
-    "redux",
-    "redis",
-    "hash"
-  ],
+  "keywords": ["reducer", "redux", "redis", "hash"],
   "author": "redradix",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:dev": "jest --watch",
     "test:coverage": "jest --coverage",
     "build": "jest && webpack",
+    "analyze": "webpack --json | webpack-bundle-size-analyzer",
     "prepublishOnly": "jest && webpack"
   },
   "keywords": ["reducer", "redux", "redis", "hash"],

--- a/src/entities/index.js
+++ b/src/entities/index.js
@@ -1,5 +1,5 @@
 import buildReducer from '../lib/buildReducer'
-import omit from 'lodash/omit'
+import omit from 'lodash.omit'
 import { get, set } from 'dot-prop-immutable'
 import * as ActionTypes from './actionTypes'
 export * from './actions'

--- a/src/entities/selectors.js
+++ b/src/entities/selectors.js
@@ -1,5 +1,5 @@
-import map from 'lodash/map'
-import curry from 'lodash/curry'
+import map from 'lodash.map'
+import curry from 'lodash.curry'
 
 const EMPTY_OBJECT = {}
 

--- a/src/entities/selectors.js
+++ b/src/entities/selectors.js
@@ -1,4 +1,3 @@
-import map from 'lodash.map'
 import curry from 'lodash.curry'
 
 const EMPTY_OBJECT = {}
@@ -14,6 +13,7 @@ export const getById = curry(function(domain, id, state) {
   return getDomain(domain, state)[id]
 })
 // get all entities as an array
-export const getAll = curry((domain, state) =>
-  map(getDomain(domain, state), value => value)
-)
+export const getAll = curry((domain, state) => {
+  const entities = getDomain(domain, state)
+  return Object.keys(entities).map(key => entities[key])
+})

--- a/src/hash/selectors.js
+++ b/src/hash/selectors.js
@@ -1,4 +1,4 @@
-import curry from 'lodash/curry'
+import curry from 'lodash.curry'
 import { get } from 'dot-prop-immutable'
 
 const EMPTY_OBJECT = {}

--- a/src/list/selectors.js
+++ b/src/list/selectors.js
@@ -1,4 +1,4 @@
-import curry from 'lodash/curry'
+import curry from 'lodash.curry'
 
 const root = state => state.list
 

--- a/src/set/selectors.js
+++ b/src/set/selectors.js
@@ -1,4 +1,4 @@
-import curry from 'lodash/curry'
+import curry from 'lodash.curry'
 
 const root = state => state.set
 


### PR DESCRIPTION
Se ha cambiado el map de lodash por el nativo, y se han arreglado los demás imports de lodash.
Aún así se podrían buscar alternativas para el omit y el curry que pesan bastante.

Así es como se queda compuesto el paquete (el lodash.map pesaba +60 KB):
```
lodash.omit: 37.36 KB (30.5%)
lodash.curry: 35.51 KB (29.0%)
dot-prop-immutable: 5.03 KB (4.11%)
process: 4.96 KB (4.05%)
invariant: 1.46 KB (1.20%)
webpack: 895 B (0.713%)
<self>: 37.35 KB (30.5%)
```